### PR TITLE
Support postgresql url and heroku

### DIFF
--- a/models/db.js
+++ b/models/db.js
@@ -50,10 +50,8 @@ module.exports.init = async () => {
         logging: process.env.NODE_ENV == 'development' ? true : false,
         connectTimeoutMS: Math.max(10*1000, r.connectTimeoutMS || 10*1000),
         timezone: r.timezone || '+00:00',
-        // dateStrings: true,
-        // extra: {
-        //   charset: (r.extra && r.extra.charset) || r.charset || "utf8mb4_general_ci",
-        // },
+        ssl: r.ssl,
+        ...connectionAttributes
       })
     } else {
       throw new Error('server error: not supported resource[type].')

--- a/models/db.js
+++ b/models/db.js
@@ -29,14 +29,23 @@ module.exports.init = async () => {
         },
       })
     } else if (r.type == 'postgres') {
+      let connectionAttributes;
+
+      if (r.url) {
+        connectionAttributes = { url: r.url }
+      } else {
+        connectionAttributes = {
+          host: r.host,
+          port: r.port || 5432,
+          username: r.username,
+          password: Buffer.from(r.password, 'base64').toString('utf-8'),
+          database: r.database,
+        }
+      }
+
       await createConnection({
         name: r.key,
         type: 'postgres',
-        host: r.host,
-        port: r.port || 3306,
-        username: r.username,
-        password: Buffer.from(r.password, 'base64').toString('utf-8'),
-        database: r.database,
         synchronize: false,
         logging: process.env.NODE_ENV == 'development' ? true : false,
         connectTimeoutMS: Math.max(10*1000, r.connectTimeoutMS || 10*1000),


### PR DESCRIPTION
To make this project heroku friendly, this PR adds some new resource configurations.

The first is the `url` attribute, we can easily configure the postgresql with a string like  `postgres://username:pass@localhost:5432/database`. The typeorm already supports the the `url` attribute.

The second is the `ssl` attribute, to be possible to config SSL, this is a required option to use heroku. The typeorm already supports the the `ssl` attribute.

With that can have a configuration like the image

![New possible config](https://user-images.githubusercontent.com/91538/171329850-ee0aa016-21aa-4a40-811f-e653a31fcd44.png)