### PR TITLE
Upgrade block api

### DIFF
--- a/routes/block.js
+++ b/routes/block.js
@@ -2316,6 +2316,20 @@ router.post('/http', [only.id(), only.menu(), upload.any(), only.expiration()], 
         r = {
           data: r
         }
+      } else if (block.responseType == 'blob') {
+        config.responseType = 'arraybuffer'
+
+        r = await external_axios(config)
+        const buffer = r.data
+
+        res.status(200)
+        res.set({
+          'Content-Disposition': r.headers.get('Content-Disposition'),
+          'Content-Type': r.headers.get('Content-Type'),
+          'Access-Control-Expose-Headers': 'Content-Disposition',
+        })
+        res.send(Buffer.from(buffer, 'binary').toString('base64'))
+        return
       } else {
         r = await external_axios(config)
       }

--- a/routes/block.js
+++ b/routes/block.js
@@ -2105,6 +2105,11 @@ router.post('/http', [only.id(), only.menu(), upload.any(), only.expiration()], 
                 value: req.session.email
               }
             }
+            else if (valueFromUserProperty == '{{id}}') {
+              found = {
+                value: req.session.id
+              }
+            }
             else if (valueFromUserProperty == '{{name}}') {
               let name = req.user_role.profile_name
               if (!name) {

--- a/routes/block.js
+++ b/routes/block.js
@@ -53,10 +53,11 @@ const get_message = (block, fields) => {
 
 const publish = (next) => {
   const io = {
-    to(name) {
+    to(channel) {
       return {
-        emit(opt) {
-          debug(`[socket.io] ${name}`, opt)
+        emit(name, opt) {
+          debug(`[socket.io]`, name)
+          console.dir(opt, {depth: null})
         }
       }
     }

--- a/routes/block.js
+++ b/routes/block.js
@@ -56,7 +56,6 @@ const publish = (next) => {
     to(channel) {
       return {
         emit(name, opt) {
-          debug(`[socket.io]`, name)
           console.dir(opt, {depth: null})
         }
       }
@@ -2261,16 +2260,25 @@ router.post('/http', [only.id(), only.menu(), upload.any(), only.expiration()], 
         const data = new FormData()
 
         if (config.json) {
-          data.append('json', JSON.stringify(config.data))
+          data.append('json', JSON.stringify(config.data), {
+            contentType: 'application/json',
+          })
         } else {
           for (const field of fields) {
             if (field.valueFromEnv) continue
-            data.append(field.key, field.value)
+            if (field.key == 'code_fields') continue
+
+            const param = block.params.find(e => e.key == field.key) || {}
+
+            data.append(field.key, field.value, {
+              contentType: param.contentType,
+            })
           }
         }
         for (const file of req.files) {
           data.append(file.fieldname, file.buffer, {
-            filename: file.originalname
+            filename: file.originalname,
+            contentType: file.contentType,
           })
         }
         config.headers = {


### PR DESCRIPTION
## 수정:

- base port 9300 통일 (일부예제 admin config not ready 원인)
- action http에서 zone 안타는 문제
- socket.io log 노출함 (클라우드 request/response 동일)
- code_fields eval 제대로 안되는문제 (array 미지원등)
- code_fields로 Array
- valueFromSelectedRows 케이스 포함
- json 통째로 보내는 방법 지원 (application/json)
- field에 contentType 지정시 해당 타입으로 전송 지원
- block 단위 권한막는기능 추가

## Fixes:

- Unified base port to 9300 (resolved the issue where admin config was not ready in some examples)
- Fixed an issue where actions were not properly routed through zones in HTTP
- Exposed socket.io logs (consistent with cloud request/response logs)
- Resolved issue with code_fields evaluation not working properly (e.g., lack of array support)
- Added support for arrays in code_fields
- Included support for the valueFromSelectedRows case
- Added support for sending entire JSON objects (application/json)
- Added support for transmitting specified contentType when defined in fields
- Added a feature to restrict permissions by block